### PR TITLE
Fix `None` type request

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ recursive-include src *.rst
 recursive-include src *.sh
 recursive-include src *.xml
 recursive-include src *.zcml
+recursive-exclude news *

--- a/news/4.bugfix
+++ b/news/4.bugfix
@@ -1,0 +1,2 @@
+Fix `None` type request.
+[petschki]

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Products.CMFPlone",
         "Products.GenericSetup",
         "zope.component",
+        "zope.globalrequest",
         "zope.i18n",
         "zope.i18nmessageid",
         "zope.interface",

--- a/src/cs/adminlanguage/negotiator.py
+++ b/src/cs/adminlanguage/negotiator.py
@@ -11,6 +11,7 @@ from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.interfaces import IFolderish
 from zope.component import ComponentLookupError
 from zope.component import getUtility
+from zope.globalrequest import getRequest
 from zope.i18n.translationdomain import TranslationDomain
 
 import logging
@@ -81,6 +82,9 @@ def get_editor_language(request):
 
     This is the cached version.
     """
+    if request is None:
+        request = getRequest()
+
     language = getattr(request, _cache_attribute_name, _marker)
     if language is _marker:
         language = _get_editor_language(request)


### PR DESCRIPTION
This fixes a traceback on our installation:

```
Traceback (most recent call last):
  File "/home/cipra/plone6/eggs/cs.adminlanguage-1.0-py3.13.egg/cs/adminlanguage/negotiator.py", line 138, in _patched_translate
    language = get_editor_language(context)
  File "/home/cipra/plone6/eggs/cs.adminlanguage-1.0-py3.13.egg/cs/adminlanguage/negotiator.py", line 87, in get_editor_language
    setattr(request, _cache_attribute_name, language)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '_cached_admin_language' and no __dict__ for setting new attributes
```